### PR TITLE
Inject afero FS abstraction for testing

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -10,6 +10,7 @@ import (
 	"lda/resources"
 	"lda/shell"
 	"lda/user"
+	"lda/util"
 	"net/http"
 	"os"
 
@@ -109,6 +110,9 @@ func setupConfig() {
 
 	// setting up the system configuration
 	config.SetupSysConfig()
+
+	// Setup afero FS layer
+	util.SetupFS()
 
 	sudoExecUser, isRoot, err := config.GetUserConfig()
 	if err != nil {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -6,8 +6,8 @@ import (
 	"lda/client"
 	gen "lda/gen/api/v1"
 	"lda/process"
+	"lda/util"
 	"net"
-	"os"
 	"strings"
 	"sync"
 
@@ -191,7 +191,7 @@ func (c *Collector) onEndCommand() {
 }
 
 func (c *Collector) collectCommandInformation() error {
-	if err := os.RemoveAll(SocketPath); err != nil {
+	if err := util.Fs.RemoveAll(SocketPath); err != nil {
 		c.logger.Error().Err(err).Msg("Failed to clean up existing socket")
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
+	"github.com/spf13/afero"
 	"html/template"
 	"lda/config"
-	"os"
+	"lda/util"
 	"os/exec"
 	"os/user"
 	"path/filepath"
@@ -93,12 +94,12 @@ func (d *Daemon) InstallDaemonConfiguration() error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(filePath), DirPermission); err != nil {
+	if err := util.Fs.MkdirAll(filepath.Dir(filePath), DirPermission); err != nil {
 		d.logger.Err(err).Msg("Failed to create directories for daemon files")
 		return fmt.Errorf("failed to create directories for daemon files: %w", err)
 	}
 
-	if err := os.WriteFile(filePath, content.Bytes(), ServicePermission); err != nil {
+	if err := afero.WriteFile(util.Fs, filePath, content.Bytes(), ServicePermission); err != nil {
 		d.logger.Err(err).Msg("Failed to write daemon files")
 		return fmt.Errorf("failed to write daemon files: %w", err)
 	}
@@ -117,7 +118,7 @@ func (d *Daemon) DestroyDaemonConfiguration() error {
 		return err
 	}
 
-	if err := os.Remove(filePath); err != nil {
+	if err := util.Fs.Remove(filePath); err != nil {
 		d.logger.Err(err).Msg("Failed to remove daemon service file")
 		return err
 	}

--- a/util/file.go
+++ b/util/file.go
@@ -11,7 +11,7 @@ import (
 
 // FileExists checks if a file exists or not
 func FileExists(filePath string) bool {
-	if _, err := os.Stat(filePath); err == nil {
+	if _, err := Fs.Stat(filePath); err == nil {
 		return true
 	} else if !os.IsNotExist(err) {
 		logging.Log.Err(err).Msg("Failed to check if file exists or not")
@@ -94,7 +94,7 @@ func ChangeFileOwnership(filePath string, user *user.User) error {
 
 // IsScriptPresent checks if a script is already present in a file
 func IsScriptPresent(filePath, script string) bool {
-	file, err := os.Open(filePath)
+	file, err := Fs.Open(filePath)
 	if err != nil {
 		return false
 	}
@@ -111,7 +111,7 @@ func IsScriptPresent(filePath, script string) bool {
 
 // AppendToFile appends content to a file
 func AppendToFile(filePath, content string) error {
-	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	f, err := Fs.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
 	if err != nil {
 		return err
 	}

--- a/util/fs.go
+++ b/util/fs.go
@@ -1,0 +1,11 @@
+package util
+
+import "github.com/spf13/afero"
+
+// Fs is the global file system instance, can be backed by real FS or MemMapFs for testing.
+var Fs afero.Fs
+
+// SetupFS initialize the file system instance. When used in testing, the Fs variable is swapped out to afero.MemMapFs.
+func SetupFS() {
+	Fs = afero.NewOsFs()
+}


### PR DESCRIPTION
Using aferofs, we can inject a custom fs for testing purposes. When the prod flavor is build, we simply wire in the OS fs and everything acts as normal.